### PR TITLE
Update to support authlib>=0.12 and remove deprecated import

### DIFF
--- a/flask_azure_oauth/__init__.py
+++ b/flask_azure_oauth/__init__.py
@@ -9,6 +9,8 @@ from flask_azure_oauth.keys import TestJwk
 
 class FlaskAzureOauth(ResourceProtector):
     def __init__(self):
+        super().__init__()
+
         self.validator = None
 
         self.azure_tenancy_id = None
@@ -36,8 +38,6 @@ class FlaskAzureOauth(ResourceProtector):
         )
 
         self.register_token_validator(self.validator)
-
-        super().__init__()
 
     def reset_app(self) -> None:
         """

--- a/flask_azure_oauth/errors.py
+++ b/flask_azure_oauth/errors.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from flask import make_response, jsonify, Response
 from authlib.common.errors import AuthlibHTTPError
 from authlib.flask.error import raise_http_exception
-from authlib.specs.rfc7519 import MissingClaimError
+from authlib.jose.errors import MissingClaimError
 
 
 class ApiException(Exception):

--- a/flask_azure_oauth/resource_protector.py
+++ b/flask_azure_oauth/resource_protector.py
@@ -14,8 +14,7 @@ class ResourceProtector(_ResourceProtector):
     - overloading the 'raise_error_response' method to catch exceptions as API errors and return them to the client
     """
 
-    @classmethod
-    def deregister_token_validator(cls, token_validator: BearerTokenValidator) -> None:
+    def deregister_token_validator(self, token_validator: BearerTokenValidator) -> None:
         """
         This method adds a counterpart to the 'register_token_validator' in the 'ResourceProtector' class to allow a
         previously registered token validator type to be removed
@@ -23,7 +22,7 @@ class ResourceProtector(_ResourceProtector):
         :type token_validator: BearerTokenValidator
         :param token_validator: Previously registered token validator
         """
-        del cls.TOKEN_VALIDATORS[token_validator.TOKEN_TYPE]
+        del self._token_validators[token_validator.TOKEN_TYPE]
 
     # noinspection PyMethodMayBeStatic
     def raise_error_response(self, error):


### PR DESCRIPTION
Hi, I do not have access to the BAS issue tracker, so I'm doing this via PR 🤞

I've made the necessary code changes to support Authlib >=0.12 which introduced [some changes](https://github.com/lepture/authlib/blob/master/docs/changelog.rst#version-012) that broke this implementation of a ResourceProtector. Otherwise, with these changes it should work smoothly. (I've omitted changes to `requirements.txt`, version number, etc).

Great work, I'm surprised this does not have more attention on pypi 💯