### PR TITLE
Making token available to access from the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ def protected_with_scope():
 def protected_with_multiple_scopes():
     return 'hello authenticated and authorised entity'
 ```
+to access token and claims from within a protected resource (decorated function). These are only available for valid and verified token.
+properties available on token:
+```
+claims
+scopes
+jwks
+```
+```python
+@app.route('/protected-with-single-scope')
+@auth('user.login')
+def protected_with_scope():
+    token = auth.validator.token
+    claims = token.claims
+    scopes = token.scopes
+    jwks = token.jwks
+    name = claims["name"]
+    userobjectid = claims["oid"]
+    loginname = claims["preferred_username"]
+    return f"hello {name}! your user id is {userobjectid} and login id: {loginname}"
+```
 
 To restrict a route to any valid user or client application (authentication):
 

--- a/flask_azure_oauth/tokens.py
+++ b/flask_azure_oauth/tokens.py
@@ -519,6 +519,7 @@ class AzureTokenValidator(BearerTokenValidator):
         self.application_id = azure_application_id
         self.client_application_ids = azure_client_application_ids
         self.jwks = azure_jwks
+        self.token : AzureToken = None
 
         super().__init__(realm=None)
 
@@ -568,7 +569,7 @@ class AzureTokenValidator(BearerTokenValidator):
             azure_jwks=self.jwks,
         )
         token.claims.validate()
-
+        self.token = token
         return token
 
     def request_invalid(self, request: Request) -> bool:


### PR DESCRIPTION
I couldn't figure out a way in the original package, so made Token available on the validator attribute. This will enable developers to read claims as a dictionary from within their code by accessing auth object. 
a better way would be injecting these claims to the app object. As this is my first real foray working with Python, wanted to keep it simple :)

Looking forward for an update to the package.