### PR TITLE
implemented Azure AD B2C tenancy support, related #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,14 @@ app.config['AZURE_OAUTH_CLIENT_APPLICATION_IDS'] = ['xxx']`
 The resource protector requires two configuration options to validate tokens correctly. These are read from the Flask
 [config object](http://flask.pocoo.org/docs/1.0/config/) through the `init_app()` method.
 
-| Configuration Option                 | Data Type | Required | Description                                                                                                                |
-| ------------------------------------ | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `AZURE_OAUTH_TENANCY`                | Str       | Yes      | ID of the Azure AD tenancy all applications and users are registered within                                                |
-| `AZURE_OAUTH_APPLICATION_ID`         | Str       | Yes      | ID of the Azure AD application registration for the application being protected                                            |
-| `AZURE_OAUTH_CLIENT_APPLICATION_IDS` | List[Str] | No       | ID(s) of the Azure AD application registration(s) for the application(s) granted access to the application being protected |
+| Configuration Option                    | Data Type | Required | Description                                                                                                                              |
+| --------------------------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `AZURE_OAUTH_TENANCY`                   | Str       | Yes      | ID of the Azure AD tenancy all applications and users are registered within                                                              |
+| `AZURE_OAUTH_APPLICATION_ID`            | Str       | Yes      | ID of the Azure AD application registration for the application being protected                                                          |
+| `AZURE_OAUTH_CLIENT_APPLICATION_IDS`    | List[Str] | No       | ID(s) of the Azure AD application registration(s) for the application(s) granted access to the application being protected               |
+| `AZURE_B2C_TENANT_MODE`                 | Bool      | No       | Enables support for Azure AD B2C tenancy, enabling dynamic JWKS source acquisition from userflows (Default: False)                       |
+| `AZURE_TENANT_NAME`                     | Str       | No       | The name of your Azure AD B2C tenancy, only required when `AZURE_B2C_TENANT_MODE` is enabled                                             |
+| `AZURE_B2C_REGISTERLOGIN_USERFLOW_NAME` | Str       | No       | The name which represents the registration and login userflow in your B2C tenancy. Only required when `AZURE_B2C_TENANT_MODE` is enabled |
 
 **Note:** If the `AZURE_OAUTH_CLIENT_APPLICATION_IDS` option is not set, all client applications will be trusted and the 
 `azp` claim, if present, is ignored.

--- a/flask_azure_oauth/__init__.py
+++ b/flask_azure_oauth/__init__.py
@@ -1,6 +1,7 @@
 import requests
 
 from flask import Flask as App
+from typing import List, Union
 
 from flask_azure_oauth.resource_protector import ResourceProtector
 from flask_azure_oauth.tokens import AzureTokenValidator, AzureToken
@@ -17,6 +18,8 @@ class FlaskAzureOauth(ResourceProtector):
         self.azure_client_application_ids = []
         self.jwks = {}
 
+        self._b2c_openid_config: Union[dict, None] = None
+
     def init_app(self, app: App):
         """
         Initialises extension using settings from the Flask application
@@ -26,8 +29,20 @@ class FlaskAzureOauth(ResourceProtector):
         """
         self.azure_tenancy_id = app.config["AZURE_OAUTH_TENANCY"]
         self.azure_application_id = app.config["AZURE_OAUTH_APPLICATION_ID"]
+
+        self.azure_b2c_tenant_mode = app.config.get("AZURE_B2C_TENANT_MODE", False)
+        self.azure_tenant_name = app.config.get("AZURE_TENANT_NAME", None)
+        self.azure_b2c_registerlogin_userflow_name = app.config.get("AZURE_B2C_REGISTERLOGIN_USERFLOW_NAME", None)
+        assert (self.azure_b2c_tenant_mode and self.azure_tenant_name and self.azure_b2c_registerlogin_userflow_name) \
+            or not self.azure_b2c_tenant_mode, \
+            "If B2C mode is enabled " \
+            "configuration options 'AZURE_TENANT_NAME' and 'AZURE_B2C_REGISTERLOGIN_USERFLOW_NAME' are required!"
+
         self.azure_client_application_ids = None
-        self.jwks = self._get_jwks()
+        if self.azure_b2c_tenant_mode:
+            self.jwks = self._get_b2c_jwks()
+        else:
+            self.jwks = self._get_jwks()
 
         try:
             self.azure_client_application_ids = app.config["AZURE_OAUTH_CLIENT_APPLICATION_IDS"]
@@ -39,6 +54,8 @@ class FlaskAzureOauth(ResourceProtector):
 
         self.validator = AzureTokenValidator(
             azure_tenancy_id=self.azure_tenancy_id,
+            azure_b2c_tenant_mode=self.azure_b2c_tenant_mode,
+            azure_b2c_issuer=self._get_b2c_issuer(),
             azure_application_id=self.azure_application_id,
             azure_client_application_ids=self.azure_client_application_ids,
             azure_jwks=self.jwks,
@@ -46,7 +63,7 @@ class FlaskAzureOauth(ResourceProtector):
 
         self.register_token_validator(self.validator)
 
-    def _get_jwks(self) -> dict:
+    def _get_jwks(self, jwks_uri: str = None) -> dict:
         """
         Retrieves a JSON Web Key Set (JWKS)
 
@@ -57,12 +74,51 @@ class FlaskAzureOauth(ResourceProtector):
         :rtype dict
         :return: JSON Web Key Set
         """
+        if jwks_uri is None:
+            # Default URI for standard AAD tenants
+            jwks_uri = f"https://login.microsoftonline.com/{self.azure_tenancy_id}/discovery/v2.0/keys"
+
         jwks_request = requests.get(
-            f"https://login.microsoftonline.com/{self.azure_tenancy_id}/discovery/v2.0/keys",
+            jwks_uri,
             params={"appid": self.azure_application_id},
         )
         jwks_request.raise_for_status()
         return jwks_request.json()
+
+    def _get_b2c_jwks(self) -> Union[dict, None]:
+        """
+        Get the valid JSON Web Key Set (JWKS) source URI from B2C userflow configuration and then acquire the
+        current JWKS from there
+        """
+        if self.azure_b2c_tenant_mode:
+            return self._get_jwks(self._get_b2c_openid_config()["jwks_uri"])
+        return None
+
+    def _get_b2c_issuer(self) -> Union[str, None]:
+        """
+        Get the valid issuer value from B2C userflow configuration
+        """
+        if self.azure_b2c_tenant_mode:
+            return self._get_b2c_openid_config()["issuer"]
+        return None
+
+    def _get_b2c_openid_config(self) -> Union[dict, None]:
+        """
+        Query the configured Azure AD B2C userflow openid configuration
+        see https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#validate-signature
+        """
+        if not self.azure_b2c_tenant_mode:
+            return None
+
+        if self._b2c_openid_config:
+            return self._b2c_openid_config
+
+        openid_config_request = requests.get(
+            f"https://{self.azure_tenant_name}.b2clogin.com/{self.azure_tenant_name}.onmicrosoft.com/{self.azure_b2c_registerlogin_userflow_name}/v2.0/.well-known/openid-configuration"
+        )
+        openid_config_request.raise_for_status()
+        self._b2c_openid_config = openid_config_request.json()
+        return self._b2c_openid_config
 
     def introspect_token(self, *, token_string: str) -> dict:
         """


### PR DESCRIPTION
adding a new B2C tenancy mode, where JWTS source url is acquired from userflow openid configuration document