### PR TITLE
Support Flask 2.0 and Authlib 0.15, fix for #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 provisioning/terraform/.terraform
+.venv

--- a/flask_azure_oauth/tokens.py
+++ b/flask_azure_oauth/tokens.py
@@ -6,7 +6,7 @@ from typing import List, Union, Callable, Optional
 # noinspection PyPackageRequirements
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from flask import Request
-from authlib.jose import JWTClaims, JWK, JWK_ALGORITHMS, jwt
+from authlib.jose import JWTClaims, JWK, jwt
 from authlib.jose.errors import (
     MissingClaimError,
     InvalidClaimError,
@@ -256,7 +256,7 @@ class AzureToken:
     errors.
     """
 
-    _jwk_lib = JWK(algorithms=JWK_ALGORITHMS)
+    _jwk_lib = JWK()
 
     def __init__(
         self,
@@ -376,9 +376,9 @@ class AzureToken:
         """
         try:
             self._jwk = self._get_jwk(self.jwks)
-            jwk = self._jwk_lib.loads(self._jwk)
+            jwk = self._jwk_lib.import_key(self._jwk)
 
-            return jwk.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode()
+            return jwk.as_pem().decode()
         except ValueError:
             auth_error_token_key_decode()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-authlib = "^0.14.1"
-Flask = "^1.1.2"
+authlib = "^0.15.0"
+Flask = "^2.0.0"
 requests = "^2.23.0"
 python = "^3.6"
 


### PR DESCRIPTION
This updates the dependencies to require flask 2.0, and subsequently adds support for authlib ^0.15 as a related fix. Fix for #16 