### PR TITLE
fix: update RSAKey importing path

### DIFF
--- a/src/flask_entra_auth/mocks/jwks.py
+++ b/src/flask_entra_auth/mocks/jwks.py
@@ -1,6 +1,5 @@
 from cryptography.hazmat.primitives import serialization
-from joserfc.jwk import KeySet
-from joserfc.rfc7518.rsa_key import RSAKey
+from joserfc.jwk import KeySet, RSAKey
 
 
 class MockJwk:


### PR DESCRIPTION
It is recommended to import from `joserfc.jwk`. The `rfcXXX` will be converted into private modules.